### PR TITLE
CR-1339: Reducing onboarding complexity between OBT and ND.

### DIFF
--- a/security/DOXM-OwnerCreds.txt
+++ b/security/DOXM-OwnerCreds.txt
@@ -44,8 +44,10 @@ OT->ND: POST /oic/sec/pstat[{..., "cm:":"bx0011,1100",...}]
 ND->OT: RSP 2.04
 OT->ND: POST /oic/sec/pstat[{..., "isop:":"TRUE",...}]
 ND->OT: RSP 2.04
-OT->ND: Close Secure Session
-OT->ND: Open Secure Session with new Owner Credentials
+
+note over OT, ND
+Provision the new device with additional credentials for device management and device-to-device communications. 
+end note
 
 @enduml
 */


### PR DESCRIPTION
A new proposal to allow use of a single encrypted session between
OBT and ND to set additional credentials, instead of setting up
a new connection after the inital onboarding.

Signed-off-by: Pawel Winogrodzki <pawelwi@microsoft.com>